### PR TITLE
Make dataSource assignable through Interface Builder

### DIFF
--- a/Source/BarGraph/GKBarGraph.h
+++ b/Source/BarGraph/GKBarGraph.h
@@ -32,7 +32,7 @@
 @property (nonatomic, assign) BOOL animated;
 @property (nonatomic, assign) CFTimeInterval animationDuration;
 
-@property (nonatomic, assign) id<GKBarGraphDataSource> dataSource;
+@property (nonatomic, weak) IBOutlet id<GKBarGraphDataSource> dataSource;
 
 @property (nonatomic, strong) NSArray *bars;
 @property (nonatomic, strong) NSArray *labels;

--- a/Source/LineGraph/GKLineGraph.h
+++ b/Source/LineGraph/GKLineGraph.h
@@ -32,7 +32,7 @@
 @property (nonatomic, assign) BOOL animated;
 @property (nonatomic, assign) CFTimeInterval animationDuration;
 
-@property (nonatomic, assign) id<GKLineGraphDataSource> dataSource;
+@property (nonatomic, weak) IBOutlet id<GKLineGraphDataSource> dataSource;
 
 @property (nonatomic, assign) CGFloat lineWidth;
 @property (nonatomic, assign) CGFloat margin;


### PR DESCRIPTION
It's common use when you assign delegates/datasources via InterfaceBuilder (like `UITableView`). I've also changed property modifier from `assign` to `weak`.
