### PR TITLE
Fixed bug in animation

### DIFF
--- a/Source/BarGraph/GKBar.m
+++ b/Source/BarGraph/GKBar.m
@@ -82,7 +82,6 @@ static CFTimeInterval kDefaultAnimationDuration = 1.0;
 - (void)setPercentage:(CGFloat)percentage animated:(BOOL)animated {
     self.animated = animated;
     self.percentage = percentage;
-    self.animated = YES;
 }
 
 - (void)setPercentage:(CGFloat)percentage {


### PR DESCRIPTION
It was setting animation to YES, regardless of the parameter value

It's a showstopper bug if someone wants to use or not use animation.
