### PR TITLE
Fixed dataSource titleForBarAtIndex to be optional

### DIFF
--- a/Source/BarGraph/GKBarGraph.m
+++ b/Source/BarGraph/GKBarGraph.m
@@ -97,10 +97,14 @@ static CGFloat kDefaultAnimationDuration = 2.0;
     if ([self _hasLabels]) [self _removeLabels];
     
     [self _constructBars];
-    [self _constructLabels];
-    
     [self _positionBars];
-    [self _positionLabels];
+    
+    if([self.dataSource respondsToSelector:@selector(titleForBarAtIndex:)])
+    {
+        [self _constructLabels];
+        [self _positionLabels];
+    }
+    
 }
 
 - (BOOL)_hasBars {


### PR DESCRIPTION
Now performs check for the dataSource to respond to the selector before actually creating/positioning the labels.

Should fix: #16 

WARNING: I haven't tested the fix locally, so you will want to test before pulling it in.